### PR TITLE
Feat/#55 이미지 s3 + iam 등록 후 이미지 업로드 한 후 추출한 경로를 통해 프로필 이미지 업로드 기능 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
+    domains: ["bookmakase.s3.ap-northeast-2.amazonaws.com"],
     remotePatterns: [
       {
         protocol: "https",

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -9,6 +9,21 @@ export interface userInformationUpdate {
   newUsername?: string;
 }
 
+export type UserRole = "USER" | "ADMIN";
+
+export interface UserProfileResponse {
+  userId: number;
+  username: string;
+  email: string;
+  createdAt: string;
+  imageUrl: string | null;
+  intro: string | null;
+  phone: string | null;
+  address: string | null;
+  point: number;
+  role: UserRole;
+}
+
 export const getMyInfo = async () => {
   try {
     const response = await instance.get(`${api.users}/me`);
@@ -54,7 +69,29 @@ export const patchAddress = async (address: string) => {
     const response = await instance.patch(`${api.users}/address`, { address });
     return response.data;
   } catch (e) {
-    console.error("주소 변경경 실패 : ", e);
+    console.error("주소 변경 실패 : ", e);
+    throw e;
+  }
+};
+
+export const updateProfileImage = async (
+  file: File
+): Promise<UserProfileResponse> => {
+  const formData = new FormData();
+  formData.append("file", file);
+  try {
+    const response = await instance.post<UserProfileResponse>(
+      `${api.users}/profile-image`,
+      formData,
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      }
+    );
+    return response.data;
+  } catch (e) {
+    console.error("이미지 업로드 실패 : ", e);
     throw e;
   }
 };

--- a/src/app/(home)/mypage/_components/MyPageNav.tsx
+++ b/src/app/(home)/mypage/_components/MyPageNav.tsx
@@ -54,7 +54,9 @@ export default function MyPageNav() {
           <Image
             alt="프로필 이미지"
             src={
-              data.imageUrl || previewUrl || "/images/profile-image-default.jpg"
+              data?.imageUrl ||
+              previewUrl ||
+              "/images/profile-image-default.jpg"
             }
             fill
             priority

--- a/src/app/(home)/mypage/_components/MyPageNav.tsx
+++ b/src/app/(home)/mypage/_components/MyPageNav.tsx
@@ -1,9 +1,51 @@
+"use client";
+
+import { useUpdateProfileImage } from "@/hooks/mutation/useUpdateProfileImage";
+import { useMyIntro } from "@/hooks/query/useMyInfo";
+import { useQueryClient } from "@tanstack/react-query";
 import Image from "next/image";
 import Link from "next/link";
-import React from "react";
+import React, { useRef, useState } from "react";
+import toast from "react-hot-toast";
 import { FaRegEdit } from "react-icons/fa";
 
 export default function MyPageNav() {
+  const { data } = useMyIntro();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const { mutate } = useUpdateProfileImage();
+
+  console.log(data);
+
+  const handleClickEdit = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) {
+      alert("이미지를 선택해주세요.");
+      return;
+    }
+
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+
+    console.log("선택된 파일 : ", file);
+
+    mutate(file, {
+      onSuccess: () => {
+        toast.success("이미지 업로드 성공했습니다!");
+        queryClient.invalidateQueries({ queryKey: ["myIntro"] });
+      },
+      onError: () => {
+        alert("이미지 업로드 실패...");
+      },
+    });
+  };
+
   return (
     <div className="min-h-[calc(100vh-200px)] flex flex-col  items-center flex-1 border-r-2 gap-16 px-2 py-20">
       {/* 이미지 콘테이너 */}
@@ -11,21 +53,33 @@ export default function MyPageNav() {
         <div className="relative w-[190px] h-[190px] border-2 rounded-full overflow-hidden">
           <Image
             alt="프로필 이미지"
-            src={"/images/profile-image-default.jpg"}
+            src={
+              data.imageUrl || previewUrl || "/images/profile-image-default.jpg"
+            }
             fill
             priority
-            className="object-contain"
+            className="object-cover"
           />
         </div>
 
         <FaRegEdit
           size={42}
+          onClick={handleClickEdit}
           className="
           absolute bottom-6 right-2
           text-black drop-shadow-sm /* 배경 밝으면 테두리 주기 */
           z-10                     /* 이미지 위로 올라오게 */
           cursor-pointer
         "
+        />
+
+        {/* 숨겨진 파일 업로드 input */}
+        <input
+          type="file"
+          accept="image/*"
+          ref={fileInputRef}
+          onChange={handleFileChange}
+          className="hidden"
         />
       </div>
 

--- a/src/app/(home)/mypage/page.tsx
+++ b/src/app/(home)/mypage/page.tsx
@@ -24,9 +24,6 @@ export default function MyPage() {
     if (data) setIntro(data.intro);
   }, [data]);
 
-  console.log("@#######################");
-  console.log(intro);
-
   const [isIntroEdit, setIsIntroEdit] = useState(false);
 
   const [currentPassword, setCurrentPassword] = useState("");
@@ -37,8 +34,6 @@ export default function MyPage() {
   const [isInformationEdit, setIsInformationEdit] = useState(false);
   const [isPasswordEdit, setIsPasswordEdit] = useState(false);
   const [isNickNameEdit, setIsNickNameEdit] = useState(false);
-
-  console.log("data : ", data);
 
   const { mutate: updateIntro, isPending: isIntroPending } = useIntroUpdate();
   const { mutate: updateInformation, isPending: isInformationPending } =
@@ -70,11 +65,6 @@ export default function MyPage() {
   };
 
   const handleClickInformationUpdate = () => {
-    // 이부분 작성해야해
-    // 비밀번호 바꿀 경우 기존 비밀번호 + 새 비밀번호+ 새 비밀번호 확인
-    // 유저네임을 바꿀경우 새 유저이름만
-    // 모두 다바꿀경우 모든 필드가 다있는 경우
-
     const payload: InformationPayload = {};
 
     if (isPasswordEdit) {

--- a/src/hooks/mutation/useUpdateProfileImage.ts
+++ b/src/hooks/mutation/useUpdateProfileImage.ts
@@ -1,0 +1,8 @@
+import { updateProfileImage, UserProfileResponse } from "@/api/user";
+import { useMutation } from "@tanstack/react-query";
+
+export const useUpdateProfileImage = () => {
+  return useMutation<UserProfileResponse, Error, File>({
+    mutationFn: updateProfileImage,
+  });
+};


### PR DESCRIPTION
## 🔧 작업 개요

- 이미지 s3 + iam 등록 후 이미지 업로드 한 후 추출한 경로를 통해 프로필 이미지 업로드 기능 추가

## ✅ 체크리스트

- [x] 관련 이슈를 링크했나요? (#55 )
- [x] 기능 동작을 테스트했나요?

## 📝 변경 사항

- 주요 변경 내용을 bullet point로 정리해주세요.
- ex) 로그인 시 알림 기능 추가, 로그인 실패 시 메시지 개선 등

## 💬 기타 사항

- 리뷰어가 알면 좋을 추가 사항이나, 논의가 필요한 부분이 있다면 적어주세요.

## 📷 스크린샷 (선택)
<img width="701" height="402" alt="image" src="https://github.com/user-attachments/assets/26a39d12-d97e-46b1-8d20-6a9c4619278a" />

