### PR TITLE
Feat: #57 - 비로그인 사용자 도서 상세페이지 접속 허용

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -80,7 +80,7 @@ export const updateProfileImage = async (
   const formData = new FormData();
   formData.append("file", file);
   try {
-    const response = await instance.post<UserProfileResponse>(
+    const response = await instance.patch<UserProfileResponse>(
       `${api.users}/profile-image`,
       formData,
       {

--- a/src/app/(home)/books/[id]/_components/ReviewItem.tsx
+++ b/src/app/(home)/books/[id]/_components/ReviewItem.tsx
@@ -5,6 +5,7 @@ import { formatDate } from "@/utils/formatDate";
 import { useMyIntro } from "@/hooks/query/useMyInfo";
 import { usePatchReview } from "@/hooks/mutation/useReview";
 import Button from "@/components/ui/Button";
+import { useAuthStore } from "@/store/auth";
 
 type ReviewProp = {
   review: Review;
@@ -20,6 +21,9 @@ export default function ReviewItem({ review }: ReviewProp) {
   // api 훅
   const { data, isLoading, isError } = useMyIntro();
   const { mutate: patchReviewMutate } = usePatchReview();
+
+  // store
+  const { isLogin } = useAuthStore();
 
   useEffect(() => {
     if (isError || data === null || data === undefined) {
@@ -53,7 +57,7 @@ export default function ReviewItem({ review }: ReviewProp) {
             </svg>
             <span>삭제된 리뷰입니다.</span>
           </div>
-          {myInfo !== null && myInfo.userId === user.userId && (
+          {isLogin && myInfo !== null && myInfo.userId === user.userId && (
             <Button
               color="main"
               variant="outline"

--- a/src/app/(home)/books/[id]/_components/StockAndPurchase.tsx
+++ b/src/app/(home)/books/[id]/_components/StockAndPurchase.tsx
@@ -63,7 +63,7 @@ export default function StockAndPurchase({
     return <div className="text-center text-gray-400 py-8">로딩 중...</div>;
   }
 
-  if (isError || myInfo === undefined || myInfo === null) {
+  if (!isLogin || isError || myInfo === undefined || myInfo === null) {
     return (
       <div className="text-center text-red-400 py-8">
         주문자 정보가 정확하지 않습니다.

--- a/src/hooks/query/useMyInfo.ts
+++ b/src/hooks/query/useMyInfo.ts
@@ -1,10 +1,14 @@
 import { getMyInfo } from "@/api/user";
 import { useQuery } from "@tanstack/react-query";
+import { useAuthStore } from "@/store/auth";
 
 export function useMyIntro() {
+  const { isLogin } = useAuthStore();
+
   return useQuery({
     queryKey: ["myIntro"],
     queryFn: getMyInfo,
     staleTime: 5,
+    enabled: isLogin,
   });
 }


### PR DESCRIPTION
## 🔧 작업 개요

- 비로그인 사용자 도서 상세페이지 접속 허용

## ✅ 체크리스트

- [x] 관련 이슈를 링크했나요? (#57 )
- [x] 기능 동작을 테스트했나요?

## 📝 변경 사항

- 도서 상세페이지의 리뷰, 주문자 정보를 불러올 때 비로그인 상태에서는 해당 훅의 동작을 비활성으로 변경
- 추가로, 사용자 이미지 업로드 오류를 발견하여 해당 api 도 수정

## 💬 기타 사항

- src/api/user.ts 파일에서  updateProfileImage의 메서드를 post에서 patch로 수정했습니다.

## 📷 스크린샷 (선택)

- 수정된 화면
<img width="1777" height="972" alt="비로그인 사용자의 도서 상세페이지 접속 허용" src="https://github.com/user-attachments/assets/9ce413ba-1d47-4312-a4e9-d15bc7a6d9f7" />
